### PR TITLE
Added new Cmdlet Get-RedisCurrentInfo Cmdlet to retrieve Redis connection information

### DIFF
--- a/RespClient/Cmdlet/Cmdlets.cs
+++ b/RespClient/Cmdlet/Cmdlets.cs
@@ -28,6 +28,18 @@ namespace Redis.PowerShell.Cmdlet
         }
     }
 
+    [Cmdlet("Get", "RedisCurrentInfo")]
+    public class GetRedisCurrentInfo : System.Management.Automation.Cmdlet
+    {
+        protected override void BeginProcessing()
+        {
+            if (Global.RespClient != null)
+            {
+                this.WriteObject(Global.RespClient);
+            }
+        }
+    }
+
     [Cmdlet("Disconnect", "RedisServer")]
     public class DisconnectRedisServer : System.Management.Automation.Cmdlet
     {

--- a/RespClient/RespClient.cs
+++ b/RespClient/RespClient.cs
@@ -25,6 +25,10 @@ namespace Redis.Protocol
         readonly int port;
         readonly int ioTimeout;
 
+        public string Host { get { return host; } }
+        public int Port { get { return port; } }
+        public int IoTimeout { get { return ioTimeout; } }
+
         Socket socket;
         BufferedStream stream;
 


### PR DESCRIPTION
Current Cmdlet not allowed us to check whether Redis server is currently connected.
Therefore I added Get-RedisCurrentInfo Cmdlet ot retrieve host, port and ioTimeout properties.

It might help user who want to check current connection information.
