### PR TITLE
Improve Get-RedisInfo

### DIFF
--- a/RespClient/Extension/RedisConfigExtension.cs
+++ b/RespClient/Extension/RedisConfigExtension.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Redis.Protocol;
+
+namespace Redis.Extension
+{
+    static class RedisConfigExtension
+    {
+        /// <summary>
+        /// Convert redis config result string to Dictionary.
+        /// </summary>
+        /// <param name="source">input Redis config returned item</param>
+        /// <returns></returns>
+        public static Dictionary<string, string> ToRedisConfigDictionary(this object source)
+        {
+            var dictionary = new Dictionary<string, string>();
+            var items = source.CastRedisString();
+
+            switch (items.Length)
+            {
+                case 1: dictionary[items[0]] = "";
+                    break;
+                case 2: dictionary[items[0]] = items[1];
+                    break;
+                default:
+                    break;
+            }
+            return dictionary;
+        }
+    }
+}

--- a/RespClient/Extension/RedisExtension.cs
+++ b/RespClient/Extension/RedisExtension.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Redis.Protocol;
+
+namespace Redis.Extension
+{
+    static class RedisExtension
+    {
+        public static string[] CastRedisString(this object source)
+        {
+            var item = source as string;
+            if (item != null) return new[] { item };
+
+            var items = source as IEnumerable<object>;
+            if (items != null) return items.Cast<string>().ToArray();
+
+            return new string[0];
+        }
+    }
+}

--- a/RespClient/Extension/RedisInfoExtension.cs
+++ b/RespClient/Extension/RedisInfoExtension.cs
@@ -1,0 +1,106 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Redis.Protocol;
+
+namespace Redis.Extension
+{
+    static class RedisInfoExtension
+    {
+        /// <summary>
+        /// Convert RedisString to RedisInfo
+        /// </summary>
+        /// <param name="source">input Redis info returned item</param>
+        /// <returns></returns>
+        public static IEnumerable<RedisInfo> AsRedisInfo(this object source)
+        {
+            // sample source input
+            /*
+            var source = @"# MEMORY
+            key1:value1
+            key2:value2
+
+            # SERVER
+            key3:sub1=value3,sub2=value4
+            key4:sub3=value5,sub4=value6
+            # HOGE
+            key5:sub5=value7"
+            */
+
+            // Get IEnumerable<RedisInfo>
+            var info = source.CastRedisString()
+                .SelectMany(x => x.Split(new[] { "#" }, StringSplitOptions.RemoveEmptyEntries))
+                .SelectMany(group =>
+                {
+                    var keys = group.Split(new[] { "\r\n" }, StringSplitOptions.RemoveEmptyEntries);
+                    // keep first line as infoType
+                    var infoType = keys.First().Replace("#", "").Trim();
+
+                    // skip first line and start for each key
+                    return keys.Skip(1).SelectMany(y =>
+                    {
+                        var kvs = y.Split(new[] { ':' }, StringSplitOptions.RemoveEmptyEntries);
+                        // first item is key
+                        var key = kvs.First();
+
+                        // skip first item and start subkey to create <RedisInfo>
+                        var values = kvs.Skip(1).SelectMany(value => value
+                            .Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
+                            .Select(sub =>
+                            {
+                                // Split subkey with =, element 1 means no subkey. The other means contains subkey. => all together into <RedisInfo>
+                                var subKvOrValue = sub.Split(new[] { '=' }, StringSplitOptions.RemoveEmptyEntries);
+                                return subKvOrValue.Length == 1 ?
+                                    new RedisInfo(infoType, key, string.Empty, subKvOrValue.First())
+                                    :
+                                    new RedisInfo(infoType, key, subKvOrValue.First(), subKvOrValue.Last());
+                            }));
+
+                        return values;
+                    });
+                });
+            return info;
+        }
+
+        /// <summary>
+        /// Filter source output with Key and SubKey
+        /// </summary>
+        /// <param name="source"></param>
+        /// <param name="Key"></param>
+        /// <param name="SubKey"></param>
+        /// <returns></returns>
+        public static IEnumerable<RedisInfo> FilterKeySubKey(this System.Collections.Generic.IEnumerable<RedisInfo> source, RedisInfoKeyType[] Key, RedisInfoSubkeyType[] SubKey)
+        {
+            return source.Select(item =>
+            {
+                RedisInfo values = null;
+                if (Key == null & SubKey == null)
+                {
+                    // When both Key and Subkey not specified
+                    values = item;
+                }
+                else if (Key != null & SubKey == null)
+                {
+                    // when Key specify and output contains it
+                    if (Key.Where(x => x.ToString() == item.Key).Any())
+                        values = item;
+                }
+                else if (Key == null & SubKey != null)
+                {
+                    // when Subkey specify and output contains it
+                    if (SubKey.Where(x => x.ToString() == item.SubKey).Any())
+                        values = item;
+                }
+                else if (Key.Where(x => x.ToString() == item.Key).Any() & SubKey.Where(x => x.ToString() == item.SubKey).Any())
+                {
+                    // when Key and Subkey specify and output contains both
+                    values = item;
+                }
+                return values;
+            });
+        }
+
+    }
+}

--- a/RespClient/RespClient.cs
+++ b/RespClient/RespClient.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net.Sockets;
@@ -17,7 +18,110 @@ namespace Redis.Protocol
         Arrays = (byte)'*'
     }
 
-    public enum RedisCommandInfoType : byte
+    public enum RedisInfoKeyType
+    {
+        redis_version,
+        redis_git_sha1,
+        redis_git_dirty,
+        redis_build_id,
+        redis_mode,
+        os,
+        arch_bits,
+        multiplexing_api,
+        gcc_version,
+        process_id,
+        run_id,
+        tcp_port,
+        uptime_in_seconds,
+        uptime_in_days,
+        hz,
+        lru_clock,
+        connected_clients,
+        client_longest_output_list,
+        client_biggest_input_buf,
+        blocked_clients,
+        used_memory,
+        used_memory_human,
+        used_memory_rss,
+        used_memory_peak,
+        used_memory_peak_human,
+        used_memory_lua,
+        mem_fragmentation_ratio,
+        mem_allocator,
+        loading,
+        rdb_changes_since_last_save,
+        rdb_bgsave_in_progress,
+        rdb_last_save_time,
+        rdb_last_bgsave_status,
+        rdb_last_bgsave_time_sec,
+        rdb_current_bgsave_time_sec,
+        aof_enabled,
+        aof_rewrite_in_progress,
+        aof_rewrite_scheduled,
+        aof_last_rewrite_time_sec,
+        aof_current_rewrite_time_sec,
+        aof_last_bgrewrite_status,
+        aof_last_write_status,
+        total_connections_received,
+        total_commands_processed,
+        instantaneous_ops_per_sec,
+        total_net_input_bytes,
+        total_net_output_bytes,
+        instantaneous_input_kbps,
+        instantaneous_output_kbps,
+        rejected_connections,
+        sync_full,
+        sync_partial_ok,
+        sync_partial_err,
+        expired_keys,
+        evicted_keys,
+        keyspace_hits,
+        keyspace_misses,
+        pubsub_channels,
+        pubsub_patterns,
+        latest_fork_usec,
+        role,
+        connected_slaves,
+        master_repl_offset,
+        repl_backlog_active,
+        repl_backlog_size,
+        repl_backlog_first_byte_offset,
+        repl_backlog_histlen,
+        used_cpu_sys,
+        used_cpu_user,
+        used_cpu_sys_children,
+        used_cpu_user_children,
+        cmdstat_set,
+        cmdstat_info,
+        db0, // up to 16 databases allowed in redis
+        db1,
+        db2,
+        db3,
+        db4,
+        db5,
+        db6,
+        db7,
+        db8,
+        db9,
+        db10,
+        db11,
+        db12,
+        db13,
+        db14,
+        db15
+    }
+
+    public enum RedisInfoSubkeyType
+    {
+        calls,
+        usec,
+        usec_per_call,
+        keys,
+        expires,
+        avg_ttl
+    }
+
+    public enum RedisInfoInfoType
     {
         Default,
         Server,
@@ -30,6 +134,25 @@ namespace Redis.Protocol
         KeySpace,
         CommandStats,
         All
+    }
+
+    /// <summary>
+    /// Container for RedisInfo command parse result
+    /// </summary>
+    public class RedisInfo
+    {
+        public string InfoType { get; set; }
+        public string Key { get; set; }
+        public string SubKey { get; set; }
+        public string Value { get; set; }
+
+        public RedisInfo(string infoType, string key, string subKey, string value)
+        {
+            this.InfoType = infoType;
+            this.Key = key;
+            this.SubKey = subKey;
+            this.Value = value;
+        }
     }
 
     public class RespClient : IDisposable
@@ -317,79 +440,6 @@ namespace Redis.Protocol
                 commands.Clear();
 
                 return result;
-            }
-        }
-
-        public class ParseRedisCommand
-        {
-            readonly string carriageReturn = "\r\n";
-            readonly char delimiter = ':';
-            readonly char valueDelimiter = ',';
-            readonly char valueDicDelimiter = '=';
-
-            /// <summary>
-            /// Cast Redis return object to string / string[]
-            /// </summary>
-            /// <param name="source">input Redis returned item</param>
-            /// <returns></returns>
-            private string[] CastString(object source)
-            {
-                var item = source as string;
-                if (item != null) return new[] { item };
-
-                var items = source as IEnumerable<object>;
-                if (items != null) return items.Cast<string>().ToArray();
-
-                return new string[0];
-            }
-
-            /// <summary>
-            /// Convert redis info result string to Dictionary.
-            /// </summary>
-            /// <param name="source">input Redis info returned item</param>
-            /// <returns></returns>
-            public Dictionary<string, object> ParseInfo(object source)
-            {
-                var dic = CastString(source)
-                    .SelectMany(x => x.Split(new string[] { carriageReturn }, StringSplitOptions.RemoveEmptyEntries))
-                    .Where(x => x.Contains(delimiter))
-                    .Select(x => x.Split(delimiter))
-                    .ToDictionary(kv => kv[0], kv =>
-                    {
-                        var split = kv[1].Split(valueDelimiter);
-                        if (split.Length == 1) return (object)split[0]; // value not contains valueDelimiter
-
-                        // check value contains valueDicDelimiter
-                        return split.Select(xs =>
-                        {
-                            var valueSplit = xs.Split(valueDicDelimiter);
-                            if (valueSplit.Length == 1) return (object)valueSplit[0]; // value not contains valueDicDelimiter
-                            return Tuple.Create(valueSplit[0], valueSplit[1]);
-                        });
-                    });
-                return dic;
-            }
-
-            /// <summary>
-            /// Convert redis config result string to Dictionary.
-            /// </summary>
-            /// <param name="source">input Redis config returned item</param>
-            /// <returns></returns>
-            public Dictionary<string, string> ParseConfig(object source)
-            {
-                var dictionary = new Dictionary<string, string>();
-
-                var items = CastString(source);
-                switch (items.Length)
-                {
-                    case 1: dictionary[items[0]] = "";
-                        break;
-                    case 2: dictionary[items[0]] = items[1];
-                        break;
-                    default:
-                        break;
-                }
-                return dictionary;
             }
         }
     }

--- a/RespClient/RespClient.csproj
+++ b/RespClient/RespClient.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>RespClient</RootNamespace>
     <AssemblyName>RespClient</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>
@@ -21,6 +21,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -29,6 +30,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -38,9 +40,13 @@
   <ItemGroup>
     <Compile Include="Cmdlet\Cmdlets.cs" />
     <Compile Include="Cmdlet\Global.cs" />
+    <Compile Include="Extension\RedisExtension.cs" />
+    <Compile Include="Extension\RedisConfigExtension.cs" />
+    <Compile Include="Extension\RedisInfoExtension.cs" />
     <Compile Include="RespClient.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
Description
----

This PR brings support -Key, -Subkey filtering support for Get-RedisInfo.

Issue : https://github.com/neuecc/RespClient/issues/22

Enhancement list
----

- Added Key, Subkey Property
- Change OutputType from Dictionary -> RedisInfo[]
- Added -Key filtering support
- Added -Subkey filtering support
- Intellisense support for Key, Subkey

Sample usage
----

```powershell
Import-Module .\RespClient.dll
Connect-RedisServer
Get-RedisInfo

# parameter input
Get-RedisInfo -Key aof_current_rewrite_time_sec,aof_enabled

# splatting support
$param = @{
    Key = "db0"
}
Get-RedisInfo @param

# Splatting multiple property
$param = @{
    Key = "db0"
    Subkey = "keys"
}
Get-RedisInfo @param

# pipeline input
"db0" | Get-RedisInfo

# pipeline splatting support
@{Key = "db0"} | %{Get-RedisInfo @_}

# pipeline with property support
[PSCustomObject]@{Key = "db0"; Subkey = "keys"} | Get-RedisInfo
```